### PR TITLE
Remove delay from Somfy move functions (replaced by a task)

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -6,6 +6,7 @@
 #include "Syslog.h"
 #include "WiFi.h"
 #include "prefs.h"
+#include "rs_scheduledtasks.h"
 
 SomfyRTS somfy(RF433_PIN);
 // A UDP instance to let us send and receive packets over UDP
@@ -39,22 +40,14 @@ void setup_syslog(){
 }
 
 void moveup(int roller) {
-
-  digitalWrite(TX_LED_PIN, HIGH);
+  TXLEDOnfor1s();
   somfy.moveup(roller);
-  delay(500);
-  digitalWrite(TX_LED_PIN, LOW);
-
 }
 
 
 void movedown(int roller) {
-
-  digitalWrite(TX_LED_PIN, HIGH);
-  somfy.movedown(roller);
-  delay(500);
-  digitalWrite(TX_LED_PIN, LOW);
-  
+  TXLEDOnfor1s();
+  somfy.movedown(roller);  
 }
 
 
@@ -69,10 +62,6 @@ void prog(int roller) {
 
 
 void stop(int roller) {
-
-  digitalWrite(TX_LED_PIN, HIGH);
-  somfy.stop(roller);
-  delay(500);
-  digitalWrite(TX_LED_PIN, LOW);
-  
+  TXLEDOnfor1s();
+  somfy.stop(roller);  
 }

--- a/src/rs_scheduledtasks.cpp
+++ b/src/rs_scheduledtasks.cpp
@@ -16,6 +16,8 @@ Task programTask(TASK_MINUTE, TASK_FOREVER, &checkTriggerProgram, &runner, false
 Task checkWifiTask(TASK_MINUTE, TASK_FOREVER, &check_wifi, &runner, false);
 // Do Wifi LED blink (every second)
 Task wifiBlinkTask(1 * TASK_SECOND, TASK_FOREVER, &wifiLEDOn, &runner, false);
+// TX LED task
+Task TXLEDTask(1 * TASK_SECOND, TASK_FOREVER, &TXLEDOff, &runner, false);
 
 void checkTriggerProgram(){
 
@@ -58,6 +60,19 @@ void refresh_programTask(void) {
     programTask.disable();
   }
   
+}
+
+void TXLEDOnfor1s(void) {
+  // Cancel task in case already running
+  TXLEDTask.cancel();
+  TXLEDTask.setCallback(&TXLEDOff);
+  TXLEDTask.enableDelayed(TASK_SECOND);
+  digitalWrite(TX_LED_PIN, HIGH);
+}
+
+void TXLEDOff(void) {
+  digitalWrite(TX_LED_PIN, LOW);
+  TXLEDTask.cancel();
 }
 
 void execute_runner(void) {

--- a/src/rs_scheduledtasks.h
+++ b/src/rs_scheduledtasks.h
@@ -10,6 +10,8 @@ void wifiLEDOff();
 void enable_wifiBlinkTask(void);
 void enable_checkWifiTask(void);
 void refresh_programTask(void);
+void TXLEDOnfor1s(void);
+void TXLEDOff(void);
 void execute_runner(void);
 
 #endif //SCHEDULEDTASKS_H_


### PR DESCRIPTION
Proposition de code pour l'extension de la LED TX afin d'éviter la fonction "delay" (qui bloque le processeur).