### PR TITLE
Rolling code

### DIFF
--- a/src/SomfyRTS.cpp
+++ b/src/SomfyRTS.cpp
@@ -37,7 +37,7 @@ void SomfyRTS::_buildFrameSomfy() {
   prefs.begin("SomfyRTS", false);
 
   char key[10];
-  snprintf(key, 10, "%lu", _RTS_address);
+  snprintf(key, 10, "%lu", _RTS_address + 2 * _virtualRemoteNumber);
   Code = prefs.getUInt(key);
   Serial.print("SomfyRTS::_buildFrameSomfy - Code read : ");
   Serial.println(Code);
@@ -46,8 +46,8 @@ void SomfyRTS::_buildFrameSomfy() {
   frame[1] = _actionCommand << 4;  // Which button did  you press? The 4 LSB will be the checksum
   frame[2] = Code >> 8;    // Rolling code (big endian)
   frame[3] = Code;         // Rolling code
-  frame[4] = _RTS_address + _virtualRemoteNumber >> 16; // Remote address
-  frame[5] = _RTS_address + _virtualRemoteNumber >>  8; // Remote address
+  frame[4] = (_RTS_address + _virtualRemoteNumber) >> 16; // Remote address
+  frame[5] = (_RTS_address + _virtualRemoteNumber) >>  8; // Remote address
   frame[6] = _RTS_address + _virtualRemoteNumber;     // Remote address
 
   // Checksum calculation: a XOR of all the nibbles

--- a/src/rs_scheduledtasks.cpp
+++ b/src/rs_scheduledtasks.cpp
@@ -12,12 +12,12 @@
 Scheduler runner;
 // Check if a program starts (checked every minute)
 Task programTask(TASK_MINUTE, TASK_FOREVER, &checkTriggerProgram, &runner, false);
-// Check Wifi (every 5mn)
+// Check Wifi (every minute)
 Task checkWifiTask(TASK_MINUTE, TASK_FOREVER, &check_wifi, &runner, false);
 // Do Wifi LED blink (every second)
-Task wifiBlinkTask(1 * TASK_SECOND, TASK_FOREVER, &wifiLEDOn, &runner, false);
+Task wifiBlinkTask(TASK_SECOND, TASK_FOREVER, &wifiLEDOn, &runner, false);
 // TX LED task
-Task TXLEDTask(1 * TASK_SECOND, TASK_FOREVER, &TXLEDOff, &runner, false);
+Task TXLEDTask(TASK_SECOND, TASK_FOREVER, &TXLEDOff, &runner, false);
 
 void checkTriggerProgram(){
 

--- a/src/rs_wifi.cpp
+++ b/src/rs_wifi.cpp
@@ -5,6 +5,7 @@
 #include "prefs.h"
 #include "ESP32Ping.h"
 #include "misc.h"
+#include "pins.h"
 
 IPAddress apIP(10, 10, 10, 1);
 DNSServer dnsServer;
@@ -44,6 +45,7 @@ void connect_to_wifi(void) {
 }
 
 void check_wifi(void){
+  digitalWrite(STATUS_LED_PIN, HIGH);
   int avg_ms = 2000;
   boolean ping_sucess = Ping.ping(IPtoPing, 9);
   avg_ms = Ping.averageTime();
@@ -67,6 +69,7 @@ void check_wifi(void){
     }
     write_output("Connection fails but reconnected :)");
   }
+  digitalWrite(STATUS_LED_PIN, LOW);
 }
 
 void start_softap(void) {


### PR DESCRIPTION
Le rolling code avance par remote (et non un code général partagé pour toutes les remotes). Attention, nécessite de ré-enregistrer les remotes puisque seule la remote 0 aura un rolling code accepté par le moteur ; les autres repartent à 0).
STATUS LED à High le temps du checkWifi (permet d'avoir une LED active de temps en temps pour confirmer la bonne exécution de l'ESP32)